### PR TITLE
deal with missing database dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,14 +40,14 @@ cli
 cli
   .command('start <configFile>')
   .description('start coolbot with given configuration file')
-  .action(path => {
+  .action(async path => {
     if (!fs.existsSync(path)) {
       console.log('config file at path does not exist');
 
       return;
     }
 
-    app.listen(3000, () => {
+    (await app()).listen(3000, () => {
       console.log(`[!] Running Web Server on localhost:3000`);
 
       startBot(path);

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,19 +1,20 @@
 import PouchDB from 'pouchdb';
 import express from 'express';
 
-const app = express();
+async function app(): Promise<express.Express> {
+  const handler = require('express-pouchdb')();
+  await handler.setPouchDB(PouchDB.defaults({
+    prefix: './database/',
+  }));
 
-app.use(
-  '/db',
-  require('express-pouchdb')(
-    PouchDB.defaults({
-      prefix: './database/',
-    }),
-  ),
-);
+  const app = express();
+  app.use('/db', handler);
 
-app.get('/', async (req: any, res: any) => {
-  res.send('home');
-});
+  app.get('/', async (req: any, res: any) => {
+    res.send('home');
+  });
+
+  return app;
+}
 
 export default app;

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,7 +1,11 @@
+import fs from 'fs';
 import PouchDB from 'pouchdb';
 import express from 'express';
 
 async function app(): Promise<express.Express> {
+  // pouchdb doesn't deal if this directory doesn't already exist
+  fs.mkdirSync("database", { recursive: true });
+
   const handler = require('express-pouchdb')();
   await handler.setPouchDB(PouchDB.defaults({
     prefix: './database/',


### PR DESCRIPTION
express-pouchdb doesn't really cope with errors setting up the database. Let's do that by hand up front so that we crash immediately instead of continuing to run in a really degraded state. Also, create the database dir if it doesn't exist so that we don't actually crash.